### PR TITLE
Correct next_release / development descrepencies

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,14 +10,14 @@ class SearchController < ApplicationController
     render :new
   end
 
-  
+
   def create
     raise "You have not supplied a plate barcode" if params[:plate_barcode].blank?
 
     find_user
-    
+
     respond_to do |format|
-      format.html { redirect_to api.search.find(Settings.searches['Find asset by barcode']).first(:barcode => params[:plate_barcode]) }
+      format.html { redirect_to api.search.find(Settings.searches['Find assets by barcode']).first(:barcode => params[:plate_barcode]) }
     end
 
 

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,7 +1,7 @@
 <%= page(:search) do %>
   <div data-role="header">
     <h1>Sequencescape - Pulldown Pipeline</h1>
-    <%= link_to "All Plates", all_outstanding_plates_path %>
+    <%= link_to "All Plates", all_outstanding_plates_path, :rel => 'external' %>
   </div>
 
   <%= content do %>

--- a/config/environments/next_release.rb
+++ b/config/environments/next_release.rb
@@ -1,0 +1,56 @@
+PulldownPipeline::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # The production environment is meant for finished, "live" apps.
+  # Code is not reloaded between requests
+  config.cache_classes = true
+
+  # Full error reports are disabled and caching is turned on
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Specifies the header that your server uses for sending files
+  config.action_dispatch.x_sendfile_header = "X-Sendfile"
+
+  # For nginx:
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
+
+  # If you have no front-end server that supports something like X-Sendfile,
+  # just comment this out and Rails will serve the files
+
+  # See everything in the log (default is :info)
+  # config.log_level = :debug
+
+  # Use a different logger for distributed setups
+  # config.logger = SyslogLogger.new
+
+  # Use a different cache store in production
+  # config.cache_store = :mem_cache_store
+
+  # Disable Rails's static asset server
+  # In production, Apache or nginx will already do this
+  config.serve_static_assets = true
+
+  # Enable serving of images, stylesheets, and javascripts from an asset server
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Disable delivery errors, bad email addresses will be ignored
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable threaded mode
+  # config.threadsafe!
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners
+  config.active_support.deprecation = :notify
+
+  # Configure the Sequencescape API
+  config.api_connection_options               = ActiveSupport::OrderedOptions.new
+  config.api_connection_options.namespace     = 'Pulldown'
+  config.api_connection_options.url           = 'http://psd-dev.internal.sanger.ac.uk:6801/api/1/'
+  config.api_connection_options.authorisation = '372d4ece3d05deda9b5588dd9d2b23a0'
+end
+


### PR DESCRIPTION
There's a difference in the search names used on the development and next_release servers.
This is now fixed to match the next_release version.
