### PR TITLE
[fixes 17687039] Tags are laid out according to pool not direction

### DIFF
--- a/app/models/pulldown/plate.rb
+++ b/app/models/pulldown/plate.rb
@@ -20,4 +20,14 @@ class Pulldown::Plate < Sequencescape::Plate
     FINAL_POOLING_PLATE_PURPOSES.include?(plate_purpose.name)
   end
   private :is_a_final_pooling_plate?
+
+  def ordered_pools
+    x = Hash.new { |h,k| h[k] = [] }
+    self.wells.each { |well| x[pool_for_well(well)] << well.location }
+    x.values
+  end
+
+  def pool_for_well(well)
+    self.pools.detect { |pool_id, wells| wells.include?(well.location) }
+  end
 end

--- a/app/views/plate_creation/tagging.html.erb
+++ b/app/views/plate_creation/tagging.html.erb
@@ -21,16 +21,14 @@
 
 
     function update_layout() {
-      var tags = tag_layouts[$('#plate_tag_layout_template_uuid option:selected').text()];
+      var tags = $(tag_layouts[$('#plate_tag_layout_template_uuid option:selected').text()]);
 
-      $('.aliquot').each(function(index){
-        var tag_id = tags[index];
-
-        $(this).
+      tags.each(function(index) {
+        $('#aliquot_'+this[0]).
           hide().
-          text(tag_id).
+          text(this[1][1]).
           removeClass().
-          addClass('aliquot colour-' + ( tag_id % 96 + 1) ).
+          addClass('aliquot colour-'+this[1][0]).
           fadeIn();
       });
     }


### PR DESCRIPTION
The tags are added to the wells based on the pools they are in not a
specific direction.  So each well contains a specific tag index and is
coloured based on the pool it is in, rather than being coloured by the
tag itself.
