### PR TITLE
22346065 handle unpooled wells in tagging

### DIFF
--- a/app/models/forms/tagging_form.rb
+++ b/app/models/forms/tagging_form.rb
@@ -79,8 +79,10 @@ module Forms
         wells.each { |well| well_to_pool[well] = pool_id }
       end
 
+      # We assume that if a well is unpooled then it is in the same pool as the previous pool.
+      prior_pool = nil
       callback = lambda do |row, column|
-        pool = well_to_pool["#{row}#{column}"] or next
+        prior_pool = pool = (well_to_pool["#{row}#{column}"] || prior_pool) or next
         [ "#{row}#{column}", pool ]
       end
       yield(callback)


### PR DESCRIPTION
Wells that are unpooled appear as completely nil in the grouping and so
the application was falling over.  This change makes them appear to be
in the same pool that as the previous well.
