### PR TITLE
22356131 add stock plate barcode to all labels

### DIFF
--- a/app/views/plates/_plate_printing.html.erb
+++ b/app/views/plates/_plate_printing.html.erb
@@ -3,7 +3,7 @@
   <%= individual_barcode_printing_form(
         @presenter.plate.barcode,
         :redirection_url => pulldown_plate_path(@presenter.plate),
-        :text            => @presenter.plate.plate_purpose.name
+        :text            => "#{@presenter.plate.plate_purpose.name} #{@presenter.plate.stock_plate.barcode.number}"
   ) %>
 <% end %>
 


### PR DESCRIPTION
All labels printed for plates in the pulldown application now include
the stock plate barcode number (just the digits) after their plate type
so that they can track it in the laboratory.
