### PR TITLE
23397197 cache has many association results

### DIFF
--- a/config/initializers/api_override_behaviour.rb
+++ b/config/initializers/api_override_behaviour.rb
@@ -1,0 +1,11 @@
+# This is a quick fix since the change in the API to pull the wells out of the plate JSON.
+# This application can cache the results of any has_many#all calls.
+class Sequencescape::Api::Associations::HasMany::AssociationProxy
+  module CacheResults
+    def all
+      @all ||= super
+    end
+  end
+
+  include CacheResults
+end


### PR DESCRIPTION
This means that the injection of the pool information should work now
that the well JSON is no longer part of the plate JSON.  It's fine to do
this as the application does not alter the results in any destructive
manner.
