### PR TITLE
[fixes #23413531] Display tag layouts correctly.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: git+ssh://git@github.com/sanger/sequencescape-client-api.git
-  revision: 61a9f96b5569cf47ed3c21d995cc0d712d207dc9
+  revision: 2970eb792b8c71da56317eafca881e05a18b1c50
   branch: master
   specs:
     sequencescape-client-api (0.0.1)

--- a/app/models/pulldown/tag_layout_template.rb
+++ b/app/models/pulldown/tag_layout_template.rb
@@ -1,0 +1,33 @@
+class Pulldown::TagLayoutTemplate < Sequencescape::TagLayoutTemplate
+  # Performs the coercion of this instance so that it behaves appropriately given the direction
+  # and walking algorithm information.
+  def coerce
+    extend("pulldown/tag_layout_template/in_#{self.direction}s".camelize.constantize)
+    extend("pulldown/tag_layout_template/walk_#{self.walking_by.gsub(/\s+/, '_')}".camelize.constantize)
+    self
+  end
+
+  # This returns an array of well location to pool pairs.  The 'walker' is responsible for actually doing the walking
+  # of the wells that are acceptable, and it calls back with the location of the well being processed.
+  def group_wells(plate, &walker)
+    well_to_pool = {}
+    plate.pools.each do |pool_id, wells|
+      wells.each { |well| well_to_pool[well] = pool_id }
+    end
+
+    # We assume that if a well is unpooled then it is in the same pool as the previous pool.
+    prior_pool = nil
+    callback = lambda do |row, column|
+      prior_pool = pool = (well_to_pool["#{row}#{column}"] || prior_pool) or next
+      emptiness = well_to_pool["#{row}#{column}"].nil?
+      [ "#{row}#{column}", pool, emptiness ]  # Triplet: [ A1, pool_id, emptiness ]
+    end
+    yield(callback)
+  end
+  private :group_wells
+
+  def tag_ids
+    tag_group.tags.keys.map!(&:to_i).sort
+  end
+  private :tag_ids
+end

--- a/app/models/pulldown/tag_layout_template/in_columns.rb
+++ b/app/models/pulldown/tag_layout_template/in_columns.rb
@@ -1,0 +1,12 @@
+module Pulldown::TagLayoutTemplate::InColumns
+  def group_wells_of_plate(plate)
+    group_wells(plate) do |well_location_pool_pair|
+      (1..12).map do |column|
+        ('A'..'H').map do |row|
+          well_location_pool_pair.call(row, column)
+        end
+      end
+    end
+  end
+  private :group_wells_of_plate
+end

--- a/app/models/pulldown/tag_layout_template/in_rows.rb
+++ b/app/models/pulldown/tag_layout_template/in_rows.rb
@@ -1,0 +1,11 @@
+module Pulldown::TagLayoutTemplate::InRows
+  def group_wells_of_plate(plate)
+    group_wells(plate) do |well_location_pool_pair|
+      ('A'..'H').map do |row|
+        (1..12).map do |column|
+          well_location_pool_pair.call(row, column)
+        end
+      end
+    end
+  end
+end

--- a/app/models/pulldown/tag_layout_template/walk_wells_in_pools.rb
+++ b/app/models/pulldown/tag_layout_template/walk_wells_in_pools.rb
@@ -1,0 +1,29 @@
+module Pulldown::TagLayoutTemplate::WalkWellsInPools
+  def generate_tag_layout(plate, tagged_wells)
+    tags   = tag_ids
+    groups = group_wells_of_plate(plate)
+    pools  = groups.map { |pool| pool.map { |w| w.try(:[], 1) } }.flatten.compact.uniq
+
+    groups.each_with_index do |current_group, group_index|
+      if group_index > 0
+        prior_group = groups[group_index - 1]
+
+        current_group.each_with_index do |(well,pool_id,emptiness), index|
+          break if prior_group.size <= index
+          pool_id ||= (index.zero? ? prior_group.last : current_group[index-1])[1]
+          next if prior_group[index][1] != pool_id
+
+          current_group.push([ well, pool_id, emptiness ])
+          current_group[index] = [nil, pool_id, true]
+        end
+      end
+
+      next if current_group.map(&:last).compact.uniq == [ true ] # Are all of the wells "empty"?
+
+      current_group.each_with_index do |(well, pool_id, _), index|
+        throw :unacceptable_tag_layout if tags.size <= index
+        tagged_wells[well] = [ pools.index(pool_id)+1, tags[index] ] unless well.nil?
+      end
+    end
+  end
+end

--- a/app/models/pulldown/tag_layout_template/walk_wells_of_plate.rb
+++ b/app/models/pulldown/tag_layout_template/walk_wells_of_plate.rb
@@ -1,0 +1,12 @@
+module Pulldown::TagLayoutTemplate::WalkWellsOfPlate
+  def generate_tag_layout(plate, tagged_wells)
+    tags, group = tag_ids, []
+    groups = group_wells_of_plate(plate).each { |g| group.concat(g) }
+    pools  = groups.map { |pool| pool.map { |w| w.try(:[], 1) } }.flatten.compact.uniq
+
+    group.each_with_index do |(well, pool_id, _), index|
+      throw :unacceptable_tag_layout if tags.size <= index
+      tagged_wells[well] = [ pools.index(pool_id)+1, tags[index] ] unless well.nil?
+    end
+  end
+end


### PR DESCRIPTION
The view of the tags that will be applied to a plate are now being
generated in an appropriate fashion, so if the template ignores the
pools then the view looks correct.
