### PR TITLE
23994191 pulldown does not display plates correctly when lhs columns missing

### DIFF
--- a/app/models/forms/baiting_form.rb
+++ b/app/models/forms/baiting_form.rb
@@ -31,26 +31,21 @@ module Forms
     end
 
     def wells
-      ('A'..'H').inject([]) do |a,r|
-        a.concat(
-          (1..12).map do |c|
-            location = "#{r}#{c}"
-            bait     = bait_library_layout_preview[location]
-            aliquot  = bait # Fudge, will be nil if no bait
+      plate.locations_in_rows.map do |location|
+        location = "#{r}#{c}"
+        bait     = bait_library_layout_preview[location]
+        aliquot  = bait # Fudge, will be nil if no bait
 
-            Hashie::Mash.new(
-              :location => location,
-              :bait     => bait,
-              :aliquots => [aliquot].compact
-            )
-          end
+        Hashie::Mash.new(
+          :location => location,
+          :bait     => bait,
+          :aliquots => [aliquot].compact
         )
-        a
       end
     end
 
     def wells_by_row
-      PlateWalking::Walker.new(wells)
+      PlateWalking::Walker.new(plate, wells)
     end
   end
 end

--- a/app/models/forms/custom_pooling_form.rb
+++ b/app/models/forms/custom_pooling_form.rb
@@ -69,7 +69,7 @@ module Forms
     end
 
     def source_wells_by_row
-      PlateWalking::Walker.new(plate.wells)
+      PlateWalking::Walker.new(plate, plate.wells)
     end
 
     def wells_by_row

--- a/app/models/plate_walking.rb
+++ b/app/models/plate_walking.rb
@@ -1,17 +1,34 @@
 module PlateWalking
   def wells_by_row
-    Walker.new(plate_to_walk.wells)
+    Walker.new(plate_to_walk, plate_to_walk.wells)
   end
 
   class Walker
-    def initialize(wells)
-      @rows = wells.inject(Hash.new {|h,k| h[k]=[]}) do |h,well|
-        h[well.location.sub(/\d+/,'')] << well; h
-      end.tap do |rows|
-        rows.each do |_, row|
-          row.sort! { |a,b| a.location.sub(/\D+/,'').to_i <=> b.location.sub(/\D+/,'').to_i }
-        end
+    class Location
+      def initialize(alphanumeric_location)
+        match = /^([A-Z])(\d+)$/.match(alphanumeric_location) or raise StandardError, "Invalid well location #{alphanumeric_location.inspect}"
+        @row, @column = match[1], match[2].to_i
       end
+
+      attr_reader :row, :column
+
+      def hash
+        to_s.hash
+      end
+
+      def eql?(location)
+        to_s.eql?(location.to_s)
+      end
+
+      def to_s
+        "#{row}#{column}"
+      end
+    end
+
+    def initialize(plate, wells)
+      well_pair = Hash[plate.locations_in_rows.map { |l| [ Location.new(l), nil ] }]
+      wells.each { |well| well_pair[Location.new(well.location)] = well }
+      @rows = well_pair.group_by { |l,_| l.row }.map { |l,w| [ l, w.map(&:last) ] }
     end
 
     delegate :each, :to => :@rows

--- a/app/models/presenters/pooled_presenter.rb
+++ b/app/models/presenters/pooled_presenter.rb
@@ -3,11 +3,11 @@ module Presenters
     include Presenters::Statemachine
 
     def walk_source
-      PlateWalking::Walker.new(plate_to_walk.wells)
+      PlateWalking::Walker.new(plate_to_walk, plate_to_walk.wells)
     end
 
     def walk_destination
-      PlateWalking::Walker.new(plate.wells)
+      PlateWalking::Walker.new(plate, plate.wells)
     end
   end
 end

--- a/app/models/pulldown/plate.rb
+++ b/app/models/pulldown/plate.rb
@@ -32,4 +32,30 @@ class Pulldown::Plate < Sequencescape::Plate
   def pool_for_well(well)
     self.pools.detect { |pool_id, wells| wells.include?(well.location) }
   end
+
+  def rows
+    case self.size
+    when 96  then ('A'..'H')
+    when 384 then ('A'..'P')
+    else          raise RuntimeError, "Unknown plate size #{self.size}"
+    end
+  end
+
+  def columns
+    case self.size
+    when 96  then (1..12)
+    when 384 then (1..24)
+    else          raise RuntimeError, "Unknown plate size #{self.size}"
+    end
+  end
+
+  def locations_in_rows
+    [].tap do |locations|
+      self.rows.each do |row|
+        self.columns.each do |column|
+          locations << "#{row}#{column}"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Plates that have missing wells on the LHS were causing the display code
to break, as it assumed that all wells on a plate were present.  This
change ensures that any wells that are not available are set to 'nil'.
