### PR TITLE
24141215 sc cap lib pcr plates in pulldown erroring because of pooling

### DIFF
--- a/app/models/pulldown/tag_layout_template.rb
+++ b/app/models/pulldown/tag_layout_template.rb
@@ -18,9 +18,10 @@ class Pulldown::TagLayoutTemplate < Sequencescape::TagLayoutTemplate
     # We assume that if a well is unpooled then it is in the same pool as the previous pool.
     prior_pool = nil
     callback = lambda do |row, column|
-      prior_pool = pool = (well_to_pool["#{row}#{column}"] || prior_pool) or next
+      prior_pool = pool = (well_to_pool["#{row}#{column}"] || prior_pool) #or next
       emptiness = well_to_pool["#{row}#{column}"].nil?
-      [ "#{row}#{column}", pool, emptiness ]  # Triplet: [ A1, pool_id, emptiness ]
+      well = pool.nil? ? nil : "#{row}#{column}"
+      [ well, pool, emptiness ]  # Triplet: [ A1, pool_id, emptiness ]
     end
     yield(callback)
   end

--- a/app/models/pulldown/tag_layout_template/walk_wells_in_pools.rb
+++ b/app/models/pulldown/tag_layout_template/walk_wells_in_pools.rb
@@ -11,7 +11,8 @@ module Pulldown::TagLayoutTemplate::WalkWellsInPools
         current_group.each_with_index do |(well,pool_id,emptiness), index|
           break if prior_group.size <= index
           pool_id ||= (index.zero? ? prior_group.last : current_group[index-1])[1]
-          next if prior_group[index][1] != pool_id
+          prior_pool_id = prior_group[index][1]
+          next if (prior_pool_id != pool_id) or prior_pool_id.nil?
 
           current_group.push([ well, pool_id, emptiness ])
           current_group[index] = [nil, pool_id, true]


### PR DESCRIPTION
Plates with wells on the LHS that are not pooled cause the pooling code
to behave oddly.  This fixes that issue by placing them in a nil pool.
It may, however, cause problems for other plates that have empty wells
in the pools.
