### PR TITLE
[#39775215] Include failed wells in pool determination

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -379,20 +379,21 @@
 
 
     SCAPE.preCapPools = function(sequencingPools, masterPlexLevel){
-      var wells, transfers = {};
+      var wells, failures, transfers = {};
 
       for (var pool in sequencingPools) {
-        wells           = SCAPE.plate.sequencingPools[pool].wells;
-        transfers[pool] = SCAPE.preCapPool(wells, masterPlexLevel);
+        wells           = SCAPE.plate.sequencingPools[pool].all_wells;
+        failures        = SCAPE.plate.sequencingPools[pool].failures;
+        transfers[pool] = SCAPE.preCapPool(wells, failures, masterPlexLevel);
       }
       return transfers;
     };
 
-    SCAPE.preCapPool = function(sequencingPool, plexLevel){
+    SCAPE.preCapPool = function(sequencingPool, failed, plexLevel){
       var wells = [];
 
       for (var i =0; i < sequencingPool.length; i = i + plexLevel){
-        wells.push(sequencingPool.slice(i, i + plexLevel));
+        wells.push(sequencingPool.slice(i, i + plexLevel).filter(function(w) { return failed.indexOf(w) == -1; }));
       }
 
       return { plexLevel: plexLevel, wells: wells };


### PR DESCRIPTION
Failed wells should not be dropped from their pool when calculating pool
boundaries based on plex level, even though they will not eventually be
transferred as part of the pool.
