### PR TITLE
Fix empty pool bug

### DIFF
--- a/app/helpers/plate_helper.rb
+++ b/app/helpers/plate_helper.rb
@@ -44,7 +44,7 @@ module PlateHelper
         group['wells']     = group['all_wells'] - group['failures']
       end
     end.sort_by do |(_,group)|
-      sortable_well_location_for(group['wells'].first)
+      sortable_well_location_for(group['wells'].first||group['all_wells'].first)
     end
 
     Hash[sorted_group_array].to_json.html_safe


### PR DESCRIPTION
Empty pools were using the wells.first for sorting, but wells first
was nill. Now falls back to all_wells.first in the event that all
wells have failed. Results in an empty well on the target plate, but
I think this is the prefered behaviour.
